### PR TITLE
[feature] provision to pass data into service handlers

### DIFF
--- a/app.go
+++ b/app.go
@@ -69,9 +69,6 @@ func NewApp(name string, strictSlash bool, cr ConfigReader) *App {
 }
 
 func (app *App) Register(_svc Service) {
-	if _svc.loglevel() == "" {
-		_svc.SetLogLevel(app.ll)
-	}
 	var (
 		api HTTPService
 		bg  BackgroundService
@@ -88,7 +85,7 @@ func (app *App) Register(_svc Service) {
 	if api != nil {
 		for path, routes := range api.routes() {
 			for _, endpoint := range routes {
-				app.mux.Handle(endpoint.Method(), api.prefix()+path, APIHandler(endpoint.Handler(), api, path, endpoint.Method(), app.LogLevel()))
+				app.mux.Handle(endpoint.Method(), api.prefix()+path, APIHandler(endpoint.Handler(), api, path, endpoint.Method(), app.LogLevel(), api.getCtxData()))
 			}
 		}
 		for _, each := range api.getChildren() {

--- a/default_context.go
+++ b/default_context.go
@@ -68,7 +68,7 @@ func (d *defaultServerContext) Param(key string) string {
 	return d.Params().Get(key)
 }
 
-func NewContext(ctx context.Context, cl *logger.CoreLogger, ll logger.LogLevel) *defaultContext {
+func NewContext(ctx context.Context, ll logger.LogLevel) *defaultContext {
 	dbc := defaultContext{
 		data:    &sync.Map{},
 		Context: ctx,
@@ -82,7 +82,7 @@ func NewServerContext(ctx context.Context, ll logger.LogLevel, res http.Response
 	if llh == "debug" {
 		ll = logger.LogLevelDebug
 	}
-	dbc := NewContext(ctx, cl, ll)
+	dbc := NewContext(ctx, ll)
 	dsc := defaultServerContext{
 		defaultContext: dbc,
 		res:            res,

--- a/default_services.go
+++ b/default_services.go
@@ -2,25 +2,24 @@ package goframe
 
 import (
 	"fmt"
-
-	"github.com/galentuo/goframe/logger"
+	"sync"
 )
 
 type service struct {
-	name     string
-	logLevel string
+	name string
+	env  *sync.Map
 }
 
 func (ds *service) Name() string {
 	return ds.name
 }
 
-func (ds *service) loglevel() string {
-	return ds.logLevel
+func (ds *service) SetInCtx(key string, value interface{}) {
+	ds.env.Store(key, value)
 }
 
-func (ds *service) SetLogLevel(ll logger.LogLevel) {
-	ds.logLevel = ll.String()
+func (ds *service) getCtxData() *sync.Map {
+	return ds.env
 }
 
 func newService(name string) service {

--- a/services.go
+++ b/services.go
@@ -1,11 +1,17 @@
 package goframe
 
-import "github.com/galentuo/goframe/logger"
+import (
+	"sync"
+)
 
 type Service interface {
+	// Name is the name of the service;
+	// this would be the prefix in case of HTTPService
 	Name() string
-	loglevel() string
-	SetLogLevel(logger.LogLevel)
+	// SetInCtx sets required data into the service context;
+	// It can be used to pass env elements like connections, configs, etc.
+	SetInCtx(key string, value interface{})
+	getCtxData() *sync.Map
 }
 
 type BackgroundService interface {


### PR DESCRIPTION
## Requirement
* Provision to pass required data like db connections into handlers

## Solution
1. Keep the data as a field in Service.
2. Pass the data into ctx while app.Register(Service)

## Example
* While Service Init
```go
db := NewDBConn()
Service.SetInCtx("db", db)
```
* In Handler `GetData(ctx goframe.Context)error`
```go
db := ctx.Get("db").(*dbConn)
```